### PR TITLE
fix(types): export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,18 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     },
     "./adapters/smsnetbd": {
       "import": "./dist/adapters/smsnetbd.mjs",
-      "require": "./dist/adapters/smsnetbd.cjs"
+      "require": "./dist/adapters/smsnetbd.cjs",
+      "types": "./dist/adapters/smsnetbd.d.ts"
     },
     "./mod": {
       "import": "./dist/mod.mjs",
-      "require": "./dist/mod.cjs"
+      "require": "./dist/mod.cjs",
+      "types": "./dist/mod.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
### [Hotfix] fix(types): export types

Fixing typo error for the pkg-exports