### PR TITLE
fix: tsup build for esm-mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,20 +107,25 @@
     "access": "public"
   },
   "tsup": {
-    "entry": [
-      "lib/index.ts",
-      "lib/mod.ts",
-      "lib/adapters/smsnetbd.ts"
-    ],
-    "format": [
-      "esm",
-      "cjs"
-    ],
-    "clean": true,
-    "dts": false,
-    "outDir": "dist",
-    "target": "es2022",
-    "splitting": false,
-    "shims": true
+  "entry": [
+    "lib/index.ts",
+    "lib/mod.ts",
+    "lib/adapters/smsnetbd.ts"
+  ],
+  "format": [
+    "esm",
+    "cjs"
+  ],
+  "clean": true,
+  "dts": false,
+  "outDir": "dist",
+  "target": "es2022",
+  "splitting": false,
+  "shims": true,
+  "outExtension": {
+    "esm": ".mjs",
+    "cjs": ".cjs"
   }
+}
+
 }


### PR DESCRIPTION
### Hotfix

- Fixed `tsup` build extensions for the esm to `.mjs`