### PR TITLE
[Hotfix] Tsup build config for output extensions

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,8 @@
       "./CODE_OF_CONDUCT_BN.md",
       "./CONTRIBUTING.md",
       "./README.md",
-      "./commitlint.config.js"
+      "./commitlint.config.js",
+      "./tsup.config.ts"
     ]
   },
   "formatter": {

--- a/package.json
+++ b/package.json
@@ -105,27 +105,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "tsup": {
-  "entry": [
-    "lib/index.ts",
-    "lib/mod.ts",
-    "lib/adapters/smsnetbd.ts"
-  ],
-  "format": [
-    "esm",
-    "cjs"
-  ],
-  "clean": true,
-  "dts": false,
-  "outDir": "dist",
-  "target": "es2022",
-  "splitting": false,
-  "shims": true,
-  "outExtension": {
-    "esm": ".mjs",
-    "cjs": ".cjs"
   }
-}
-
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [
+    'lib/index.ts',
+    'lib/mod.ts',
+    'lib/adapters/smsnetbd.ts'
+  ],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  outDir: 'dist',
+  target: 'es2022',
+  splitting: false,
+  shims: true,
+  outExtension: {
+    esm: '.mjs',
+    cjs: '.cjs'
+  }
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,20 +1,18 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: [
-    'lib/index.ts',
-    'lib/mod.ts',
-    'lib/adapters/smsnetbd.ts'
-  ],
-  format: ['esm', 'cjs'],
+  entry: ["lib/index.ts", "lib/mod.ts", "lib/adapters/smsnetbd.ts"],
+  format: ["esm", "cjs"],
   clean: true,
   dts: false,
-  outDir: 'dist',
-  target: 'es2022',
+  outDir: "dist",
+  target: "es2022",
   splitting: false,
   shims: true,
-  outExtension: {
-    esm: '.mjs',
-    cjs: '.cjs'
-  }
+  outExtension: ({ format }) => {
+    if (format === "esm") {
+      return { js: ".mjs" };
+    }
+    return { js: ".cjs" };
+  },
 });


### PR DESCRIPTION
### [Hotfix] Tsup build config for output extensions

✅ Fixed tsup outExtensions as:

```ts
import { defineConfig } from "tsup";

export default defineConfig({
  entry: ["lib/index.ts", "lib/mod.ts", "lib/adapters/smsnetbd.ts"],
  format: ["esm", "cjs"],
  clean: true,
  dts: false,
  outDir: "dist",
  target: "es2022",
  splitting: false,
  shims: true,
  outExtension: ({ format }) => {
    if (format === "esm") {
      return { js: ".mjs" };
    }
    return { js: ".cjs" };
  },
});

```